### PR TITLE
Add url rule to get CSRF token for external apps.

### DIFF
--- a/charat2/__init__.py
+++ b/charat2/__init__.py
@@ -78,6 +78,8 @@ app.add_url_rule("/settings", "settings", account.settings_get, methods=("GET",)
 app.add_url_rule("/settings", "settings_post", account.settings_post, methods=("POST",))
 app.add_url_rule("/settings/timezone", "settings_timezone", account.settings_timezone, methods=("POST",))
 
+app.add_url_rule("/csrf_token", "csrf_token", account.csrf_token, methods=("GET",))
+
 # 2. Chats list
 
 make_rules("rp", "/chats", chat_list.chat_list, formats=True, paging=True)

--- a/charat2/views/account.py
+++ b/charat2/views/account.py
@@ -228,3 +228,5 @@ def settings_timezone():
         g.user.timezone = request.form["timezone"]
     return "", 204
 
+def csrf_token():
+    return jsonify({"csrf_token": g.csrf_token})


### PR DESCRIPTION
Title says all. This is so weird tricks involving HTML scraping wouldn't have to happen to get the token.