### PR TITLE
Update Ubuntu in Dockerfile to the latest and add dockerignore file.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 # Create limited user for Celery
 RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
@@ -7,7 +7,9 @@ RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
 WORKDIR /home/user
 
 # Update packages and install pip
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get -y install python python-pip python-dev libpq-dev libffi-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
+	apt-get -y install python python-setuptools python-pip python-dev libpq-dev libffi-dev && \
+	rm -rf /var/lib/apt/ /var/cache/apt
 
 # Add and install Python modules
 ADD requirements.txt /home/user/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,13 +21,16 @@ kombu==3.0.34
 librabbitmq==1.6.1
 Mako==1.0.3
 MarkupSafe==0.23
+ndg-httpsclient==0.4.0
 paginate==0.4.3
 psycopg2==2.6
+pyasn1==0.1.9
 pycparser==2.13
+pyOpenSSL>=0.13
 pytz==2015.4
 redis==2.10.5
 hiredis==0.2.0
-requests[security]==2.9.1
+requests==2.9.1
 six==1.10.0
 speaklater==1.3
 SQLAlchemy==1.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ bcrypt==1.1.1
 billiard==3.3.0.22
 celery==3.1.23
 certifi==2015.9.6.2
-cffi==1.1.2
+cffi==1.6.0
 classtools==0.1
 Flask==0.10.1
 flower==0.8.3


### PR DESCRIPTION
This upgrades the base image version to Ubuntu 16.04 which gives us more up to date packages. 
This also adds a dockerignore file and deletion of the apt caches to save space when pushed up to the servers.

Requirements inside the requirements.txt is split because of a bug with the setuptools that is bundled with 16.04. pypa/setuptools#523