### PR TITLE
Fix token key for welcome emails

### DIFF
--- a/newparp/helpers/email.py
+++ b/newparp/helpers/email.py
@@ -17,11 +17,17 @@ subjects = {
     "reset": "Reset your password",
 }
 
+keys = {
+    "welcome": "verify",
+    "verify": "verify",
+    "reset": "reset",
+}
+
 
 def send_email(action, email_address):
     email_token = str(uuid4())
     g.redis.setex(
-        ":".join([action, str(g.user.id), email_address]),
+        ":".join([keys[action], str(g.user.id), email_address]),
         expiry_times[action],
         email_token,
     )

--- a/newparp/views/settings.py
+++ b/newparp/views/settings.py
@@ -110,7 +110,10 @@ def verify_email():
         token = request.args["token"].strip()
     except (KeyError, ValueError):
         abort(404)
-    stored_token = g.redis.get("verify:%s:%s" % (user_id, email_address))
+    stored_token = (
+        g.redis.get("verify:%s:%s" % (user_id, email_address))
+        or g.redis.get("welcome:%s:%s" % (user_id, email_address))
+    )
     if not user_id or not email_address or not token or not stored_token:
         abort(404)
 


### PR DESCRIPTION
New verification tokens will be created with the `verify:` prefix, and the verify view checks for existing tokens with the `welcome:` prefix. The latter can be removed in 24 hours when they expire.